### PR TITLE
Fixed typo for E-flat pitch base

### DIFF
--- a/tin_whistle_tablature.qml
+++ b/tin_whistle_tablature.qml
@@ -132,7 +132,7 @@ MuseScore {
             basePitch = 74   // D tuning (the most common)
             tabOffsetY = -1.0
          } else if (instrument == "wind.flutes.whistle.tin.eflat") {
-            basePitch = 71   // E flat tuning
+            basePitch = 75   // E flat tuning
             tabOffsetY = -1.0
          } else if (instrument == "wind.flutes.whistle.tin.f") {
             basePitch = 77   // F tuning


### PR DESCRIPTION
The pitch base for the E-flat whistle was too low, fixed so that it is a semi-tone above D whistle.