### PR TITLE
fix for #16 MuseScore 3 plugin no longer executes

### DIFF
--- a/tin_whistle_tablature.qml
+++ b/tin_whistle_tablature.qml
@@ -58,15 +58,15 @@ MuseScore {
    }
 
    // For diagnostic use.
-   function dumpObjectEntries (obj, showUndefinedVals, title) {
-      console.log("VV -------- " + title + " ---------- VV")
-      for (let [key, value] of Object.entries(obj)) {
-         if (showUndefinedVals || (value != null)) {
-            console.log(key + "=" + value);
-         }
-      }
-      console.log("^^ -------- " + title + " ---------- ^^")
-   }
+//   function dumpObjectEntries (obj, showUndefinedVals, title) {
+//      console.log("VV -------- " + title + " ---------- VV")
+//      for (let [key, value] of Object.entries(obj)) {
+//         if (showUndefinedVals || (value != null)) {
+//            console.log(key + "=" + value);
+//         }
+//      }
+//      console.log("^^ -------- " + title + " ---------- ^^")
+//   }
 
    onRun: {
       console.log("hello tin whistle tablature")


### PR DESCRIPTION
This is a temporary fix for MuseScore running on Mac OSX. For some reason function dumpObjectEntries() stops this plugin from loading and therefore is not shown in the plugins drop down menu. Needs investigation as to why this is happening for this platform only.